### PR TITLE
scripts: Create ~/.git dir incase it doesnt exist

### DIFF
--- a/linuxsetup.sh
+++ b/linuxsetup.sh
@@ -62,7 +62,7 @@ chmod a+x ~/bin/repo
 source ~/.zshrc
 
 # Add the Gerrit change-id hook
-mkdir ~/.git/hooks
+mkdir -p ~/.git/hooks
 git config --global core.hooksPath ~/.git/hooks
 curl -Lo ~/.git/hooks/commit-msg https://review.aosip.dev/tools/hooks/commit-msg
 chmod u+x ~/.git/hooks/commit-msg


### PR DESCRIPTION
* As the script progresses, it has never created a ~/.git, this script can potentially fail on fresh system.